### PR TITLE
[#3] 팔로우 기능

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,29 @@
+# app/dependencies.py
+import os
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+from database import get_db
+from app.models.user import User
+import jwt
+
+SECRET_KEY = os.getenv("SECRET_KEY")
+ALGORITHM = "HS256"
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> User:
+    if SECRET_KEY is None:
+        raise RuntimeError("SECRET_KEY 환경변수가 설정되어 있지 않습니다.")
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id = payload.get("user_id")
+        if user_id is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials")
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials")
+
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return user

--- a/app/models/follow.py
+++ b/app/models/follow.py
@@ -1,0 +1,15 @@
+# app/models/follow.py
+from sqlalchemy import Column, BigInteger, TIMESTAMP, ForeignKey
+from sqlalchemy.orm import relationship
+from app.database import Base  # 여기서 Base 임포트
+from app.models.user import User  # User 클래스 import
+
+class Follow(Base):
+    __tablename__ = "follows"
+
+    follower_id = Column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    following_id = Column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    created_at = Column(TIMESTAMP, server_default="CURRENT_TIMESTAMP")
+
+    follower = relationship(User, foreign_keys=[follower_id])
+    following = relationship(User, foreign_keys=[following_id])

--- a/app/routers/follow.py
+++ b/app/routers/follow.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from app.utils.auth import get_current_user
+from app.database import get_db
+from app.schemas.follow import FollowCreate, FollowResponse
+from app.models.user import User
+from pydantic import BaseModel
+from app.services.follow_service import (
+    follow_user,
+    unfollow_user,
+    get_following_list,
+    get_follower_list,
+    get_user_by_nickname,
+    get_users_by_nickname_like_or_404,
+)
+
+
+router = APIRouter()
+
+
+class NicknameSearchResponse(BaseModel):
+    user_id: int
+    nickname: str
+
+    class Config:
+        orm_mode = True
+
+
+@router.post("/", response_model=FollowResponse)
+def create_follow(
+    follow_data: FollowCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    follow = follow_user(db, current_user.id, follow_data.following_id)
+    return follow
+
+
+@router.get("/search-by-nickname/", response_model=list[NicknameSearchResponse])
+def search_users(
+    nickname: str,
+    db: Session = Depends(get_db),
+):
+    users = get_users_by_nickname_like_or_404(db, nickname)
+    return [NicknameSearchResponse(user_id=u.id, nickname=u.nickname) for u in users]
+
+
+@router.post("/follow-user/")
+def follow_user_by_id(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    follow_user(db, current_user.id, user_id)
+    return {"detail": f"{user_id} 번 사용자를 팔로우했습니다."}
+
+
+@router.delete("/{following_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_follow(
+    following_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    unfollow_user(db, current_user.id, following_id)
+
+
+@router.get("/following", response_model=list[FollowResponse])
+def list_following(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return get_following_list(db, current_user.id)
+
+
+@router.get("/followers", response_model=list[FollowResponse])
+def list_followers(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return get_follower_list(db, current_user.id)

--- a/app/schemas/follow.py
+++ b/app/schemas/follow.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+class FollowCreate(BaseModel):
+    following_id: int  # 팔로우할 사용자 ID
+
+class FollowResponse(BaseModel):
+    follower_id: int
+    following_id: int
+    created_at: datetime  
+
+    class Config:
+        orm_mode = True
+
+class NicknameSearchResponse(BaseModel):
+    user_id: int
+    nickname: str

--- a/app/services/follow_service.py
+++ b/app/services/follow_service.py
@@ -1,0 +1,48 @@
+from sqlalchemy.orm import Session
+from fastapi import HTTPException, status
+from app.models.follow import Follow  # ORM 모델
+from app.models.user import User
+
+def get_users_by_nickname_like(db: Session, nickname: str):
+    pattern = f"%{nickname}%"
+    users = db.query(User).filter(User.nickname.ilike(pattern)).all()
+    return users  # 빈 리스트 반환 허용
+
+def get_users_by_nickname_like_or_404(db: Session, nickname: str):
+    users = get_users_by_nickname_like(db, nickname)
+    if not users:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="해당하는 닉네임 사용자를 찾을 수 없습니다.")
+    return users
+
+def get_user_by_nickname(db: Session, nickname: str) -> User:
+    user = db.query(User).filter(User.nickname == nickname).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="사용자를 찾을 수 없습니다.")
+    return user
+
+def follow_user(db: Session, follower_id: int, following_id: int) -> Follow:
+    if follower_id == following_id:
+        raise HTTPException(status_code=400, detail="본인은 팔로우할 수 없습니다.")
+    
+    exists = db.query(Follow).filter_by(follower_id=follower_id, following_id=following_id).first()
+    if exists:
+        raise HTTPException(status_code=400, detail="이미 팔로우 중입니다.")
+    
+    follow = Follow(follower_id=follower_id, following_id=following_id)
+    db.add(follow)
+    db.commit()
+    db.refresh(follow)
+    return follow
+
+def unfollow_user(db: Session, follower_id: int, following_id: int):
+    follow = db.query(Follow).filter_by(follower_id=follower_id, following_id=following_id).first()
+    if not follow:
+        raise HTTPException(status_code=404, detail="팔로우 관계가 존재하지 않습니다.")
+    db.delete(follow)
+    db.commit()
+
+def get_following_list(db: Session, user_id: int):
+    return db.query(Follow).filter_by(follower_id=user_id).all()
+
+def get_follower_list(db: Session, user_id: int):
+    return db.query(Follow).filter_by(following_id=user_id).all()


### PR DESCRIPTION

### 사용자 간의 네트워크 형성을 위해 팔로우(follow) 기능을 구현하였습니다. 본 기능은 사용자가 다른 사용자를 팔로우하여 서로 소식을 공유하고, 관심사의 확장을 돕도록 설계되었습니다.

-----------------------------

#### 1. 핵심 기능
팔로우 생성: 로그인한 사용자가 특정 사용자를 팔로우할 수 있습니다.
팔로우 취소: 기존에 팔로우한 상대를 언팔로우합니다.
팔로잉 목록 조회: 내가 팔로우하는 사용자 목록을 볼 수 있습니다.
팔로워 목록 조회: 나를 팔로우하는 사용자 목록을 확인할 수 있습니다.
닉네임 유사 검색: 검색창에 닉네임 일부를 입력하여 유사한 닉네임 사용자들을 리스트로 반환, 선택 후 팔로우 가능

-----------------------------

#### 2. 데이터베이스 설계
follows 테이블: 팔로우 관계를 저장하는 테이블로, 다음 컬럼들로 구성
|      컬럼명      |        타입      |                          설명                            |
|---------------|--------------|------------------------------------------|
|  follower_id  |     BIGINT     |   팔로우하는 사용자 ID (users.id 참조)   |
| following_id |     BIGINT     | 팔로우 당하는 사용자 ID (users.id 참조) |
|   created_at  | TIMESTAMP |                   팔로우 생성 시간                 |

복합 기본키: (follower_id, following_id)로 중복 데이터 방지
On Delete Cascade: 사용자가 탈퇴할 경우 관련 팔로우 관계 자동 제거

-----------------------------

#### 3. 백엔드 구현
- 3.1. ORM 모델 (app/models/follow.py)
SQLAlchemy ORM Follow 모델을 정의
User 모델과의 관계(relationship)를 명시하여 편리한 조인과 조회 가능

- 3.2. 서비스 로직 (app/services/follow_service.py)
팔로우 관련 핵심 비즈니스 로직을 담당
주요 함수:
follow_user: 팔로우 생성, 중복 및 자기 팔로우 방지
unfollow_user: 팔로우 관계 제거
get_following_list, get_follower_list: 각각 팔로잉/팔로워 목록 조회
get_users_by_nickname_like: 닉네임 일부 포함 검색 기능 구현
get_user_by_nickname: 정확한 닉네임 사용자 조회, 없으면 예외 발생

- 3.3. 라우터 (app/routers/follow.py)
FastAPI 라우터로 URL 엔드포인트를 구현
닉네임 유사 검색 결과를 리스트로 반환하는 API와 선택한 사용자를 팔로우하는 API 분리
인증 및 DB 세션 의존성 주입을 통해 현재 로그인한 사용자를 자동으로 식별

-----------------------------

#### 4. 기능 흐름 예시
사용자가 팔로우하려는 대상의 닉네임 일부를 입력하여 /search-by-nickname/ GET 요청으로 유사 사용자 목록 조회
클라이언트는 이 목록을 UI에 표시하고, 사용자가 팔로우할 사용자 선택
선택한 사용자 ID를 /follow-user/ POST 요청으로 전달하여 팔로우 생성
사용자는 자신의 팔로잉/팔로워 목록을 각각 조회하여 네트워크 상태 확인 가능
#3 